### PR TITLE
add basic build cicd

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -5,7 +5,7 @@ jobs:
   build-test-job:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.04
+      image: ubuntu:22.04
       options: --cpus 1
     steps:
       - name: checkout

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  push:
+jobs:
+  build-test-job:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
+      options: --cpus 1
+    steps:
+      - name: checkout
+        uses: "actions/checkout@v4"
+      - name: Run Build Test
+        run: ./scripts/run_build_test.sh

--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -4,9 +4,6 @@ on:
 jobs:
   build-test-job:
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:22.04
-      options: --cpus 1
     steps:
       - name: checkout
         uses: "actions/checkout@v4"

--- a/make_linux.sh
+++ b/make_linux.sh
@@ -39,6 +39,7 @@ elif [ "$1" = "build" ]; then
     echo -e "[ START: ] Building the binaries now (including hpcmgr and now-server) ..."
     mkdir -p ./build
     rm -rf ./build/*
+    set -e
     ${compiler} ./hpcopr/*.c -Wall -lpthread -o ./build/hpcopr-lin-${hpcopr_version_code}.exe
     ${compiler} -c ./hpcopr/general_funcs.c -Wall -o ./installer/gfuncs.o
     ${compiler} -c ./hpcopr/opr_crypto.c -Wall -o ./installer/ocrypto.o

--- a/scripts/run_build_test.sh
+++ b/scripts/run_build_test.sh
@@ -1,0 +1,11 @@
+# Copyright (C) 2022-present Shanghai HPC-NOW Technologies Co., Ltd.
+# This code is distributed under the license: MIT License
+# Originally written by Zhenrong WANG
+# mailto: zhenrongwang@live.com | wangzhenrong@hpc-now.com
+
+#!/bin/bash
+
+set -e
+cd $(dirname $0)/..
+rm -rf build && ./make_linux.sh build
+exit 0


### PR DESCRIPTION
just an idea. to check PR and commits for buildability automatically each push.

here is an example of it working already
https://github.com/rudi-cilibrasi/hpc-now/actions/workflows/buildtest.yaml